### PR TITLE
 #5 fix navigation on highlighted code

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -234,7 +234,7 @@ $(window).load(function() {
 
 		var $firstLine = $('#' + parseInt(matches[0]));
 		if ($firstLine.length > 0) {
-			$document.scrollTop($firstLine.offset().top);
+			$right.scrollTop($firstLine.position().top);
 		}
 	}
 


### PR DESCRIPTION
I fix it scrolling `<div id="right">` instead of `document`. In this case I use `$firstLine.position()` to scroll the page relatively to div#right
