### PR TITLE
Disable HTML escaping for @param's description

### DIFF
--- a/src/function.latte
+++ b/src/function.latte
@@ -39,7 +39,7 @@
 			<td class="value"><code>{block|strip}
 				<var>{if $parameter->passedByReference}&amp; {/if}${$parameter->name}</var>{if $parameter->defaultValueAvailable} = {$parameter->defaultValueDefinition|highlightPHP:$function|noescape}{elseif $parameter->unlimited},…{/if}
 			{/block}</code></td>
-			<td>{$parameter->description|description:$function}</td>
+			<td>{$parameter->description|description:$function|noescape}</td>
 		</tr>
 		</table>
 	</div>


### PR DESCRIPTION
Currently, the following source code:

``` php
/**
 * Returns the absolute URL of a theme asset.
 *
 * @param string  $relative_url If the URL starts with `@bower/`, the prefix will be the value of
 *                              `$GLOBALS['bower_components_root_url']` if it exists
 * @param boolean $escape       If the URL should be escaped for HTML output
 *
 * @return string
 */
function get_asset($relative_url, $escape = true)
{
    // […]
}
```

will generate the following result when parsed by ApiGen:

![Screenshot](https://cloud.githubusercontent.com/assets/8007715/7025121/afcdba22-dd41-11e4-9ebb-1c2f3b3c5df9.png)

So, for the descriptions of `@param` tags, Markdown gets parsed all right, but the template escapes the generated HTML, resulting in escaped `<p>` and `<code>` tags, loosing their effect on page layout.

I don't think that this is the desired behavior, since for all other tags (`@trows`, `@return`, etc.) the HTML tags are **not** escaped.
