### PR TITLE
Indicate with mouse cursor that table row is clickable

### DIFF
--- a/src/resources/style.css
+++ b/src/resources/style.css
@@ -288,6 +288,10 @@ h2.switchable {
 	text-align: left;
 }
 
+.summary tr td {
+	cursor: pointer;
+}
+
 .summary tr:hover td {
 	background: #f6f6f4;
 }


### PR DESCRIPTION
I sometimes don't even realize the row is actually clickable (and you have to click on it to show details about the property).

### Before
Unless you do some blind-clicking, you have no idea the row could be expanded.
![screenshot_20170115_150850](https://cloud.githubusercontent.com/assets/793041/21963115/d7a69e18-db34-11e6-867d-cbac84907af6.png)


### After
The click-to-expand is clearly indicated with mouse cursor.
![screenshot_20170115_150300](https://cloud.githubusercontent.com/assets/793041/21963117/db0f109e-db34-11e6-9abe-cf1ec83f59d2.png)

